### PR TITLE
feat: 리프카테고리들만 저장되도록 수정

### DIFF
--- a/src/main/java/capstone/safeat/member/application/MemberUpdater.java
+++ b/src/main/java/capstone/safeat/member/application/MemberUpdater.java
@@ -23,8 +23,9 @@ public class MemberUpdater {
     return memberRepository.save(Member.createOAuthMember(oauthMemberInfo));
   }
 
-  public void saveCategoryIntoMember(final Member member, final List<Category> leafCategories) {
-    final List<MemberCategory> memberCategories = leafCategories.stream()
+  public void saveCategoryIntoMember(final Member member, final List<Category> categories) {
+    final List<MemberCategory> memberCategories = categories.stream()
+        .filter(Category::isLeaf)
         .map(category -> new MemberCategory(member.getId(), category))
         .toList();
     memberCategoryRepository.saveAll(memberCategories);

--- a/src/test/java/capstone/safeat/group/application/GroupServiceTest.java
+++ b/src/test/java/capstone/safeat/group/application/GroupServiceTest.java
@@ -181,8 +181,8 @@ class GroupServiceTest extends ServiceTest {
   @Test
   void 멤버들의_카테고리_목록을_반환한다() {
     //given
-    final List<Category> creatorCategories = List.of(Category.APPLE, Category.NUTS);
-    final List<Category> memberCategories = List.of(Category.WILD_CHIVE, Category.NUTS);
+    final List<Category> creatorCategories = List.of(Category.APPLE, Category.KIWI);
+    final List<Category> memberCategories = List.of(Category.WILD_CHIVE, Category.KIWI);
     final List<Category> expected = Stream.of(creatorCategories, memberCategories)
         .flatMap(List::stream)
         .distinct()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close : #63 

## 📝 작업 내용

- MemberCategory들을 저장할 때 leaf만 저장되도록 수정

## 예상 소요 시간 및 실제 소요 시간 (일 / 시간 / 분)

예상 소요 시간 : 30분
실제 소요 시간 : 10분

